### PR TITLE
Add configurable database path support

### DIFF
--- a/LCCU Database.py
+++ b/LCCU Database.py
@@ -7,6 +7,8 @@ import os
 import random
 import tkinter.font as tkFont
 
+from config import get_database_path
+
 
 def resource_path(relative_path):
     """Get absolute path to resource (compatible met PyInstaller onefile)."""
@@ -18,11 +20,18 @@ def resource_path(relative_path):
 
 
 # --- DATABASE SETUP ---
-DB_PATH = r"\\\\file01.storage\\smB-usr-lrnas\\lr-lccu\\Bruno\\objecten.db"
-
-
 def connect_db():
-    return sqlite3.connect(DB_PATH)
+    db_path = get_database_path()
+    try:
+        return sqlite3.connect(db_path)
+    except sqlite3.Error as exc:
+        messagebox.showerror(
+            "Databasefout",
+            "Kon geen verbinding maken met de database.\n"
+            "Controleer of het pad bereikbaar is of stel een lokaal pad in via de configuratie.\n\n"
+            f"Pad: {db_path}\nFout: {exc}",
+        )
+        return None
 
 
 def _normalize_datetime_value(value: str | None) -> str | None:
@@ -44,6 +53,8 @@ def normalize_datetime_fields():
     conn: sqlite3.Connection | None = None
     try:
         conn = connect_db()
+        if conn is None:
+            return
         cursor = conn.cursor()
         columns = [
             "datum_in_behandeling",
@@ -73,6 +84,8 @@ def normalize_datetime_fields():
 def create_table():
     try:
         conn = connect_db()
+        if conn is None:
+            return
         cursor = conn.cursor()
         cursor.execute(
             """
@@ -106,6 +119,8 @@ def create_table():
 def create_medewerkers_bijstand_table():
     try:
         conn = connect_db()
+        if conn is None:
+            return
         cursor = conn.cursor()
         cursor.execute(
             """
@@ -410,6 +425,8 @@ class LCCUDatabaseApp:
             sin = sin[:4].upper() + sin[4:]
         try:
             conn = connect_db()
+            if conn is None:
+                return
             cursor = conn.cursor()
             cursor.execute(
                 """
@@ -461,6 +478,8 @@ class LCCUDatabaseApp:
         try:
             datum_ingave = self.current_iso_timestamp()
             conn = connect_db()
+            if conn is None:
+                return
             cursor = conn.cursor()
             cursor.execute(
                 """
@@ -787,6 +806,8 @@ class LCCUDatabaseApp:
             query += " AND (" + " OR ".join(date_conditions) + ")"
         try:
             conn = connect_db()
+            if conn is None:
+                return
             cursor = conn.cursor()
             cursor.execute(query, tuple(params))
             results = cursor.fetchall()
@@ -1043,6 +1064,8 @@ class LCCUDatabaseApp:
         )
         try:
             conn = connect_db()
+            if conn is None:
+                return
             cursor = conn.cursor()
             cursor.execute(
                 """

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # Database-werk
+
 Database LCCU verder uitwerken
+
+## Databaseconfiguratie
+
+De applicatie gebruikt standaard de netwerkdatabase op het UNC-pad
+`\\\\file01.storage\\smB-usr-lrnas\\lr-lccu\\Bruno\\objecten.db`. Wanneer dit pad
+niet bereikbaar is, kun je een alternatief pad instellen via één van de
+volgende opties (in onderstaande volgorde van prioriteit):
+
+1. **Omgevingsvariabele** – stel `LCCU_DB_PATH` in op het volledige pad naar je
+   databasebestand.
+2. **INI-configuratie** – maak een `config.ini` (of `settings.ini`) bestand in de
+   projectmap met:
+   ```ini
+   [database]
+   path = C:\\pad\\naar\\objecten.db
+   ```
+3. **JSON-configuratie** – maak een `config.json` (of `settings.json`) bestand in
+   de projectmap met bijvoorbeeld:
+   ```json
+   {
+     "database_path": "C:/pad/naar/objecten.db"
+   }
+   ```
+   of
+   ```json
+   {
+     "database": {
+       "path": "C:/pad/naar/objecten.db"
+     }
+   }
+   ```
+
+De applicatie controleert eerst de omgevingsvariabele, daarna de aanwezige
+configuratiebestanden en valt anders terug op het standaard UNC-pad.
+
+### Lokale ontwikkeling
+
+Voor lokale ontwikkeling kun je eenvoudig een kopie van de database maken en
+het pad ernaartoe opgeven met één van de bovenstaande methoden. Bijvoorbeeld:
+
+```bash
+set LCCU_DB_PATH=C:\\Users\\<naam>\\Desktop\\objecten_dev.db  # Windows
+export LCCU_DB_PATH="/Users/<naam>/objecten_dev.db"              # macOS/Linux
+```
+
+Of plaats een `config.ini` in dezelfde map als de applicatie met het pad naar je
+lokale database. Zodra de applicatie wordt gestart, toont ze een duidelijke
+foutmelding als de opgegeven locatie niet bereikbaar is.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,86 @@
+"""Helpers voor het laden van databaseconfiguratie."""
+
+from __future__ import annotations
+
+import json
+import os
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Iterable, Optional
+
+DEFAULT_DB_PATH = (
+    r"\\\\file01.storage\\smB-usr-lrnas\\lr-lccu\\Bruno\\objecten.db"
+)
+ENV_VAR_NAME = "LCCU_DB_PATH"
+INI_FILENAMES: tuple[str, ...] = ("config.ini", "settings.ini")
+JSON_FILENAMES: tuple[str, ...] = ("config.json", "settings.json")
+
+
+def _candidate_directories() -> Iterable[Path]:
+    """Return plausible directories that may contain configuration files."""
+    here = Path(__file__).resolve().parent
+    cwd = Path.cwd()
+    # Use an ordered set-like approach to avoid duplicates while preserving order
+    seen: set[Path] = set()
+    for directory in (cwd, here):
+        if directory not in seen:
+            seen.add(directory)
+            yield directory
+
+
+def _load_from_ini(path: Path) -> Optional[str]:
+    parser = ConfigParser()
+    try:
+        with path.open(encoding="utf-8") as fh:
+            parser.read_file(fh)
+    except OSError:
+        return None
+    if parser.has_option("database", "path"):
+        value = parser.get("database", "path").strip()
+        if value:
+            return value
+    return None
+
+
+def _load_from_json(path: Path) -> Optional[str]:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    value: Optional[str] = None
+    if isinstance(data, dict):
+        if "database_path" in data:
+            candidate = data.get("database_path")
+            if isinstance(candidate, str) and candidate.strip():
+                value = candidate.strip()
+        if value is None:
+            database_section = data.get("database")
+            if isinstance(database_section, dict):
+                candidate = database_section.get("path")
+                if isinstance(candidate, str) and candidate.strip():
+                    value = candidate.strip()
+    return value
+
+
+def get_database_path() -> str:
+    """Resolve the database path from environment variables or config files."""
+    env_value = os.getenv(ENV_VAR_NAME)
+    if env_value and env_value.strip():
+        return env_value.strip()
+
+    for directory in _candidate_directories():
+        for filename in INI_FILENAMES:
+            ini_path = directory / filename
+            if ini_path.exists():
+                value = _load_from_ini(ini_path)
+                if value:
+                    return value
+        for filename in JSON_FILENAMES:
+            json_path = directory / filename
+            if json_path.exists():
+                value = _load_from_json(json_path)
+                if value:
+                    return value
+
+    return DEFAULT_DB_PATH


### PR DESCRIPTION
## Summary
- add a configuration helper that resolves the database path from environment or config files with a UNC fallback
- update the Tkinter app to use the helper and surface a friendly error when the database connection fails
- document how to override the database location for local development

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e13fb43c0c8322915b664790d8f560