### PR TITLE
Fix bijstand type handling and add test

### DIFF
--- a/tests/test_bijstand_insert.py
+++ b/tests/test_bijstand_insert.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).resolve().parents[1] / "LCCU Database.py"
+    sys.path.insert(0, str(module_path.parent))
+    spec = importlib.util.spec_from_file_location("lccu_database", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bijstand_insert_stores_type(tmp_path, monkeypatch):
+    module = load_module()
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("LCCU_DB_PATH", str(db_path))
+
+    module.check_or_create_database()
+
+    object_id = module.insert_bijstand_record(
+        soort_bijstand="Noodhulp",
+        dienst="DOT",
+        medewerkers=["Alice", "Bob"],
+        start_bijstand="2024-01-01 10:00:00",
+        einde_bijstand="2024-01-01 12:00:00",
+        datum_ingave="2024-01-01 09:00:00",
+        unique_id=1234,
+    )
+
+    with module.connect_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT type, soort_bijstand FROM objecten WHERE id = ?",
+            (object_id,),
+        )
+        row = cursor.fetchone()
+
+    assert row == ("Bijstand", "Noodhulp")


### PR DESCRIPTION
## Summary
- ensure bijstand inserts always store the literal "Bijstand" in the type column by routing the popup through a shared helper
- normalise bijstand records when loading them into the edit form so the radio button selects the Bijstand option and the subtype is shown
- add a pytest covering bijstand insertion to confirm the stored type value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15e1571088322b8900c4b46fe8af0