### PR TITLE
Add documentation for handleiding and wiki structure

### DIFF
--- a/docs/handleiding.md
+++ b/docs/handleiding.md
@@ -1,0 +1,117 @@
+# Handleiding LCCU Database Applicatie
+
+## Voorbladvoorstel
+- **Titel:** LCCU Database Applicatie – Handleiding
+- **Versie:** 1.0
+- **Datum:** $(date +%d-%m-%Y)
+- Voeg een illustratie toe van het architectuuroverzicht (zie Mermaid-diagram hieronder).
+
+## Inhoudsopgave
+1. Deel 1 – De code
+2. Deel 2 – Werking van het programma
+3. Bijlagen
+
+---
+
+## Deel 1 – De code
+
+### Architectuur in vogelvlucht
+Het startpunt is de functie `main()` in `LCCU Database.py`. Deze functie zorgt dat de SQLite-tabellen bestaan en start daarna het Tkinter-hoofdvenster (`LCCUDatabaseApp`). De databaseverbindingen verlopen via `connect_db()` dat het pad ophaalt uit de configuratie.
+
+```mermaid
+graph TD
+    A[main()] --> B[check_or_create_database()]
+    B --> B1[create_table()]
+    B --> B2[create_medewerkers_bijstand_table()]
+    B --> B3[normalize_datetime_fields()]
+    A --> C[LCCUDatabaseApp/MainWindow]
+    C --> D[IngaveTab]
+    C --> E[ZoekenTab]
+    C --> F[BewerkenTab]
+    C --> G[BijstandPopup]
+    subgraph Configuratie
+        H[config.get_database_path()]
+    end
+    D -->|Schrijft records| I[(SQLite: objecten)]
+    G -->|Voegt bijstand toe| I
+    F -->|Past records aan| I
+    G -->|Logt medewerkers| J[(SQLite: medewerkers_bijstand)]
+```
+
+### Componentoverzicht
+| Module | Rol |
+| --- | --- |
+| `config.py` | Bepaalt het databasepad via omgevingsvariabelen, INI- en JSON-bestanden en valt terug op een UNC-standaardpad. |
+| `LCCU Database.py` | Centrale applicatielogica: database-initialisatie, datumhelpers, lijsten met diensten/medewerkers, Tkinter-hoofdscherm en bijstandsinvoer. |
+| `views/ingave.py` | Tabblad “Ingave” voor het registreren van objecten, inclusief SIN-validatie en specifieke comboboxen per type. |
+| `views/zoeken.py` | Tabblad “Zoeken” met filters op SIN en datums en weergave in een `Treeview`. |
+| `views/bewerken.py` | Tabblad “Bewerken” met dubbele-klikselectie, datumvalidatie en updates van bijstand- en medewerkersgegevens. |
+| `views/bijstand_popup.py` | Popup voor het registreren van bijstandsdossiers, met dynamische medewerkersvelden en datumcontroles. |
+
+### Databaselaag
+- Tabel `objecten` bevat de kerngegevens (SIN, type, subcategorie, merk, OS, dienst, datums, enz.).
+- Tabel `medewerkers_bijstand` houdt medewerkers per bijstandsrecord bij met een foreign key naar `objecten`.
+- Bij het opstarten worden bestaande datumvelden genormaliseerd naar ISO-formaat zodat vergelijkingen en queries betrouwbaar zijn.
+
+### Hulpfuncties en validaties
+- `insert_bijstand_record` schrijft het hoofddossier en de gekoppelde medewerkers weg en vult ontbrekende waarden (datum, uniek nummer) aan.
+- `_validate_sin` accepteert enkel vier letters gevolgd door vier cijfers of het sleutelwoord `BIJSTAND`.
+- Datumhelpers converteren tussen Nederlands formaat en ISO-stempels voor opslag en presentatie.
+
+### GUIState en MainWindow
+- `GUIState` bundelt alle `StringVar`- en `BooleanVar`-instanties zodat tabbladen dezelfde data delen.
+- `MainWindow` configureert het venster (titel, icoon, grootte) en registreert de drie tabbladen plus de bijstand-popup.
+- De lijst met mogelijke diensten wordt gedeeld tussen de verschillende schermen.
+
+---
+
+## Deel 2 – Werking van het programma
+
+### Opstarten
+1. Zorg dat de gewenste SQLite-locatie beschikbaar is (zie Bijlage A).
+2. Start het programma; het hoofdvenster bevat drie tabbladen: **Ingave**, **Zoeken** en **Bewerken**.
+
+### Ingave-tabblad
+1. Vul het SIN-nummer in; het veld forceert hoofdletters en maximaal acht tekens.
+2. Kies het type (Mobile, Computer of Bijstand). Bij “Bijstand” opent automatisch de popup voor extra gegevens.
+3. Selecteer subcategorie, merk, besturingssysteem en dienst (diensten komen uit de vaste lijst).
+4. Klik op **Opslaan**; bij een fout in het SIN verschijnt een melding, anders worden de gegevens opgeslagen.
+
+### Bijstand-popup
+- De popup vraagt soort bijstand, aantal medewerkers, dienst en start-/einddatum. Het aantal medewerkers bepaalt dynamisch hoeveel naamvelden zichtbaar zijn.
+- Datums worden gevalideerd op formaat en chronologie; bij fouten verschijnt een melding.
+- Opslaan schrijft zowel het objectrecord als de medewerkers naar de database.
+
+### Zoeken-tabblad
+1. Filter optioneel op (deel van) een SIN of op een datumvenster; je kunt kiezen om ook `datum_ingave` mee te nemen.
+2. Resultaten verschijnen in een tabel; datums worden getoond in leesbaar Nederlands formaat en kolommen schalen automatisch.
+3. **Reset** wist filters en resultaten.
+
+### Bewerken-tabblad
+1. Dubbelklik in het zoekresultaat om een record te laden; de tab schakelt automatisch naar **Bewerken** en vult alle velden in, inclusief bijstandsgegevens.
+2. Aangepaste datums worden gecontroleerd op formaat en logische volgorde.
+3. SIN’s worden opnieuw gevalideerd voordat wijzigingen worden opgeslagen.
+4. Bij bijstand-records worden gekoppelde medewerkers opnieuw opgeslagen en het aantal wordt bijgewerkt.
+5. Bij succes verschijnt een bevestiging en worden de zoekresultaten ververst.
+
+---
+
+## Bijlage A – Configuratie en beheer
+- Stel de omgevingsvariabele `LCCU_DB_PATH` in voor een alternatief databasepad.
+- Of gebruik `config.ini`/`config.json` met een `database.path`-sleutel; bij afwezigheid wordt het UNC-standaardpad gebruikt.
+- Alle verbindingen gebruiken `sqlite3` en worden netjes gesloten via context managers of expliciete afsluiting.
+
+## Bijlage B – Validaties en foutafhandeling
+- Datumwaarden worden genormaliseerd bij opstart en bij elke invoer; ongeldige waarden worden geweigerd met duidelijke meldingen.
+- Bijstandsinvoer vult automatisch `aantal_medewerkers` op basis van het aantal geselecteerde medewerkers.
+
+---
+
+## PDF Genereren
+1. Kopieer (of link) dit document naar `handleiding.md` in een aparte documentatiemap.
+2. Voeg optioneel screenshots toe in de relevante secties.
+3. Converteer naar PDF met bijvoorbeeld Pandoc:
+   ```bash
+   pandoc docs/handleiding.md -o handleiding.pdf --from gfm --toc --pdf-engine=xelatex
+   ```
+4. Controleer in de PDF of het diagram goed wordt gerenderd. Als Mermaid niet wordt ondersteund, render het diagram vooraf en voeg de afbeelding in.

--- a/wiki/Beheer-en-troubleshooting.md
+++ b/wiki/Beheer-en-troubleshooting.md
@@ -1,0 +1,29 @@
+# Beheer en troubleshooting
+
+## Veelvoorkomende problemen
+
+### Databasepad niet gevonden
+- Controleer of `LCCU_DB_PATH` correct staat ingesteld.
+- Verifieer `config.ini` of `config.json` op een geldige `database.path`-waarde.
+- Controleer netwerktoegang tot het UNC-pad.
+
+### Foutmelding bij datumvelden
+- Zorg dat datums het formaat `dd-mm-jjjj` hebben in de UI.
+- Controleer of de einddatum niet voor de startdatum ligt.
+- Bekijk logica in `parse_date` en `format_date` voor conversieproblemen.
+
+### SIN-validatie faalt
+- Gebruik vier hoofdletters gevolgd door vier cijfers (bijvoorbeeld `ABCD1234`).
+- Voor bijstandsrecords mag `BIJSTAND` gebruikt worden.
+
+### Bijstand-medewerkers ontbreken
+- Controleer of het aantal geselecteerde medewerkers overeenkomt met de ingevulde namen.
+- De tabel `medewerkers_bijstand` wordt opgeschoond en opnieuw gevuld bij elke opslag.
+
+## Onderhoud
+- Maak periodiek back-ups van de SQLite-database.
+- Documenteer wijzigingen in de lijst van diensten in `LCCU Database.py`.
+- Houd dependencies up-to-date en test bij upgrades van Python of Tkinter.
+
+## Logging
+Momenteel is er geen uitgebreide logging ingebouwd. Overweeg bij productiegebruik het toevoegen van logging via het `logging`-pakket of het schrijven van audit-entries in een aparte tabel.

--- a/wiki/Handleiding/Deel-1-Code.md
+++ b/wiki/Handleiding/Deel-1-Code.md
@@ -1,0 +1,60 @@
+# Deel 1 – De code
+
+## Overzicht van modules
+| Module | Beschrijving |
+| --- | --- |
+| `config.py` | Vangt databaseconfiguratie op via environment, INI en JSON. |
+| `LCCU Database.py` | Start de applicatie, creëert tabellen en bevat hulpfuncties en Tkinter-logica. |
+| `views/ingave.py` | UI voor het invoeren van objecten en bijstand. |
+| `views/zoeken.py` | UI voor het filteren en tonen van resultaten. |
+| `views/bewerken.py` | UI voor het selecteren en bijwerken van records. |
+| `views/bijstand_popup.py` | Popup voor extra bijstandsinformatie en medewerkers. |
+
+## Architectuurdiagram
+```mermaid
+graph TD
+    main --> db[(SQLite)]
+    main --> ui[LCCUDatabaseApp]
+    ui --> ingave
+    ui --> zoeken
+    ui --> bewerken
+    ingave --> db
+    zoeken --> db
+    bewerken --> db
+    subgraph Bijstand
+        popup --> db
+    end
+```
+
+## Belangrijke functies
+- `check_or_create_database()` maakt tabellen aan als ze ontbreken en normaliseert datumvelden.
+- `insert_bijstand_record()` schrijft records naar `objecten` en `medewerkers_bijstand`.
+- `_validate_sin()` controleert of een SIN vier letters gevolgd door vier cijfers is of `BIJSTAND`.
+- `parse_date()` en `format_date()` converteren tussen Nederlands en ISO-formaat.
+
+## Databasestructuur
+### objecten
+| Kolom | Type | Opmerking |
+| --- | --- | --- |
+| `sin` | TEXT | Unieke identificatie of `BIJSTAND`. |
+| `type` | TEXT | Mobile / Computer / Bijstand. |
+| `subcategorie` | TEXT | Verdere specificatie per type. |
+| `dienst` | TEXT | Vaste lijst van diensten. |
+| `datum_ingave` | TEXT | ISO-datumtijd. |
+| `start_datum` | TEXT | Start van bijstand. |
+| `eind_datum` | TEXT | Einde van bijstand. |
+| ... | ... | Zie `LCCU Database.py` voor alle kolommen. |
+
+### medewerkers_bijstand
+| Kolom | Type | Opmerking |
+| --- | --- | --- |
+| `id` | INTEGER | Primaire sleutel. |
+| `object_id` | INTEGER | Foreign key naar `objecten.id`. |
+| `naam` | TEXT | Naam van de medewerker. |
+
+## Configuratiepadlogica
+`config.get_database_path()` zoekt in deze volgorde:
+1. Omgevingsvariabele `LCCU_DB_PATH`
+2. `config.ini` → sectie `database`, sleutel `path`
+3. `config.json` → sleutel `database.path`
+4. Default UNC-pad gedefinieerd in de module

--- a/wiki/Handleiding/Deel-2-Gebruik.md
+++ b/wiki/Handleiding/Deel-2-Gebruik.md
@@ -1,0 +1,35 @@
+# Deel 2 – Gebruik
+
+## Opstarten
+1. Controleer of het databasepad bereikbaar is.
+2. Start de applicatie met `python "LCCU Database.py"`.
+3. Het hoofdvenster toont de tabbladen **Ingave**, **Zoeken** en **Bewerken**.
+
+## Ingave
+1. Vul het SIN in (vier letters + vier cijfers of `BIJSTAND`).
+2. Kies een type. Bij type “Bijstand” wordt de bijstand-popup automatisch geopend.
+3. Selecteer subcategorie, merk, OS en dienst.
+4. Vul eventuele extra velden in en klik op **Opslaan**.
+
+## Bijstand-popup
+- Kies soort bijstand, dienst en vul start/einddatum in.
+- Selecteer het aantal medewerkers. Het venster toont evenveel naamvelden als opgegeven aantal.
+- Datums worden gevalideerd op formaat en chronologie.
+- Klik op **Opslaan** om zowel het object als de medewerkers vast te leggen.
+
+## Zoeken
+1. Gebruik filters op SIN, datum of beide.
+2. Klik op **Zoeken**; resultaten verschijnen in een tabel.
+3. Dubbelklik op een resultaat om details te bekijken of over te gaan naar **Bewerken**.
+4. **Reset** wist alle filters en resultaten.
+
+## Bewerken
+1. Selecteer een record via het **Zoeken**-tabblad.
+2. De velden worden ingevuld; pas gewenste waarden aan.
+3. Controleer datums en SIN op geldigheid.
+4. Klik op **Opslaan** om wijzigingen door te voeren.
+5. Bij bijstandsrecords worden gekoppelde medewerkers geactualiseerd op basis van de invoer.
+
+## Meldingen en foutafhandeling
+- Ongeldige SIN of datums genereren directe foutmeldingen.
+- Succesvolle bewerkingen tonen een bevestiging.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,20 @@
+# LCCU Database Applicatie
+
+De LCCU Database applicatie helpt bij het registreren, zoeken en bewerken van objecten en bijstandsaanvragen. Deze wiki beschrijft de installatie, werking en beheeraspecten van het project.
+
+```mermaid
+graph TD
+    A[Gebruiker] --> B[Ingave]
+    A --> C[Zoeken]
+    A --> D[Bewerken]
+    B --> E[(SQLite database)]
+    C --> E
+    D --> E
+```
+
+## Navigatie
+- [Installatie en configuratie](Installatie-en-configuratie.md)
+- [Deel 1 – Code](Handleiding/Deel-1-Code.md)
+- [Deel 2 – Gebruik](Handleiding/Deel-2-Gebruik.md)
+- [Beheer en troubleshooting](Beheer-en-troubleshooting.md)
+- [Testen en kwaliteitscontrole](Testen-en-kwaliteitscontrole.md)

--- a/wiki/Installatie-en-configuratie.md
+++ b/wiki/Installatie-en-configuratie.md
@@ -1,0 +1,41 @@
+# Installatie en configuratie
+
+## Vereisten
+- Python 3.10 of hoger
+- `pip` voor het installeren van dependencies
+- Toegang tot het gewenste netwerkpad voor de SQLite-database
+
+## Stappenplan
+1. **Repository clonen**
+   ```bash
+   git clone <repository-url>
+   cd Database-werk
+   ```
+
+2. **Virtuele omgeving aanmaken (optioneel maar aanbevolen)**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   ```
+
+3. **Dependencies installeren**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   > Bestaat er geen `requirements.txt`, installeer dan minimaal `tk` (voor Tkinter) en `python-dotenv` indien configuratie via `.env` wordt gebruikt.
+
+4. **Databasepad configureren**
+   - Zet de omgevingsvariabele `LCCU_DB_PATH` naar het gewenste pad; of
+   - Vul `config.ini` of `config.json` aan met een `database.path`-sleutel; of
+   - Gebruik de standaard UNC-locatie zoals gedefinieerd in `config.py`.
+
+5. **Applicatie starten**
+   ```bash
+   python "LCCU Database.py"
+   ```
+
+## Database-initialisatie
+Bij de eerste start maakt het programma automatisch de tabellen `objecten` en `medewerkers_bijstand` aan en normaliseert bestaande datumvelden.
+
+## PDF-handleiding genereren
+Volg de stappen in [`docs/handleiding.md`](../docs/handleiding.md) om een PDF-versie van de handleiding te maken met behulp van Pandoc.

--- a/wiki/Testen-en-kwaliteitscontrole.md
+++ b/wiki/Testen-en-kwaliteitscontrole.md
@@ -1,0 +1,20 @@
+# Testen en kwaliteitscontrole
+
+## Handmatige regressietests
+| Scenario | Stappen | Verwacht resultaat |
+| --- | --- | --- |
+| SIN-validatie | Voer `ABCD1234` in, sla op. Probeer `abcd1234` of `12345678`. | Eerste wordt geaccepteerd, andere geven foutmelding. |
+| Datumcontrole | Vul startdatum `01-01-2024`, einddatum `31-12-2023`. | Applicatie geeft foutmelding over datumvolgorde. |
+| Bijstand-medewerkers | Kies type “Bijstand”, voeg 2 medewerkers toe, sla op en heropen. | Beide medewerkers verschijnen opnieuw. |
+| Zoeken op SIN | Voeg record toe met SIN `WXYZ0001` en zoek op `WXYZ`. | Record verschijnt in resultaten. |
+
+## Automatische tests
+Er is een voorbeeldtest in `tests/test_bijstand_insert.py` die controleert of bijstandsinvoer correct wordt opgeslagen. Voer de testreeks uit met:
+```bash
+pytest
+```
+
+## Kwaliteitsrichtlijnen
+- Gebruik branches en pull requests voor elke wijziging.
+- Laat code reviews uitvoeren door minimaal één collega.
+- Houd deze wiki up-to-date bij wijzigingen in functionaliteit of UI.


### PR DESCRIPTION
## Summary
- add a comprehensive `docs/handleiding.md` for generating the PDF manual
- scaffold GitHub wiki pages covering installation, usage, troubleshooting, and testing guidance

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e177c938148322b84c305a854082bf